### PR TITLE
Add timecodes support for local media

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: '22'
+          package-manager-cache: false
       - name: Environment details
         run: pnpm version
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
   Build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 1
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
       - name: Install pnpm
@@ -37,15 +37,15 @@ jobs:
     needs: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Download coverage data
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: lcov.info
           path: coverage/
       - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@v4
+        uses: SonarSource/sonarqube-scan-action@v6
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,11 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 1
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v5
         with:
           node-version: '22'
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
       - name: Environment details
         run: pnpm version
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v5
         with:
           node-version: '22'
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
       - name: Environment details
         run: pnpm version
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: '22'
+          package-manager-cache: false
       - name: Environment details
         run: pnpm version
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,8 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
       - name: Install pnpm

--- a/src/TimecodesPlugin.ts
+++ b/src/TimecodesPlugin.ts
@@ -1,9 +1,15 @@
-import { Plugin } from 'obsidian'
+import { MarkdownPostProcessorContext, Plugin } from 'obsidian'
 
 import { turnRawTimecodesIntoClickableLinks } from './ui/timecodes-md-post-processor'
 
 export default class TimecodesPlugin extends Plugin {
   override onload() {
-    this.registerMarkdownPostProcessor(turnRawTimecodesIntoClickableLinks)
+    this.registerMarkdownPostProcessor(
+      (root: HTMLElement, ctx: MarkdownPostProcessorContext) => {
+        requestAnimationFrame(() => {
+          turnRawTimecodesIntoClickableLinks(root, ctx)
+        })
+      },
+    )
   }
 }

--- a/src/ui/timecodes-md-post-processor.ts
+++ b/src/ui/timecodes-md-post-processor.ts
@@ -1,6 +1,7 @@
 import { MarkdownPostProcessorContext } from 'obsidian'
 
 import { Timecode } from '../types'
+import { timecodeToSeconds } from '../utils/timecode-converter'
 import { TIMECODE_REGEXP, matchesIterator as timeCodeMatcher } from '../utils/timecode-parser'
 import { createTimecodedYouTubeLink, findYouTubeVideoId } from '../utils/youtube-links'
 
@@ -35,6 +36,9 @@ export function turnRawTimecodesIntoClickableLinks(
       }
       if (elementNode instanceof HTMLIFrameElement) {
         textForFindingVideoLink = elementNode.src
+      }
+      if (elementNode instanceof HTMLMediaElement) {
+        latestRequiredEnricher = localMedicaEnricherFor(elementNode)
       }
     } else if (node.nodeType === Node.TEXT_NODE) {
       const textNode = node as Text
@@ -115,6 +119,20 @@ const youtubeEnricherFor = (videoId: string): TextTimecodeEnricher => ({
     link.target = '_blank'
     link.textContent = rawTimecodeText
     link.ariaLabel = timecodedLink
+    return link
+  },
+})
+
+const localMedicaEnricherFor = (media: HTMLMediaElement): TextTimecodeEnricher => ({
+  composeLinkElementWithTimecode: (raw, timecode) => {
+    const link = document.createElement('a')
+    link.href = '#'
+    link.textContent = raw
+    link.addEventListener('click', (e) => {
+      e.preventDefault()
+      media.currentTime = timecodeToSeconds(timecode)
+      void media.play()
+    })
     return link
   },
 })

--- a/src/ui/timecodes-md-post-processor.ts
+++ b/src/ui/timecodes-md-post-processor.ts
@@ -7,6 +7,11 @@ import { createTimecodedYouTubeLink, findYouTubeVideoId } from '../utils/youtube
 let latestRequiredEnricher: TextTimecodeEnricher | null = null
 let latestNoteBeingProcessed: string | null = null
 
+/*
+ * From my observations, MarkdownPostProcessor:
+ * - gets called once for each paragraph in a note
+ * - doesn't get called again on subsequent switch to view-mode unless there was a change in paragraph
+ */
 export function turnRawTimecodesIntoClickableLinks(
   root: HTMLElement,
   ctx: MarkdownPostProcessorContext,


### PR DESCRIPTION
Adds support for:
- local audio
- local video

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Clickable timecodes now link to specific timestamps in YouTube videos.
  - Timecodes can control embedded/local media, seeking and playing from the specified time.
- Improvements
  - Timecode enrichment runs only when relevant media is detected, reducing unnecessary processing.
  - Rendering feels smoother due to deferred processing during note rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->